### PR TITLE
refactor: badge issuer

### DIFF
--- a/src/components/molecules/StepModal.tsx
+++ b/src/components/molecules/StepModal.tsx
@@ -370,7 +370,7 @@ export const StepModal: React.FC<ModalProps> = ({
         badgeType => {
           const badgeIdVector = xdr.ScVal.scvVec([
             xdr.ScVal.scvString(badgeType.name),
-            new Address(pubkey).toScVal(),
+            new Address(badgeType.issuer.toUpperCase()).toScVal(),
           ]);
           return new xdr.ScMapEntry({
             key: badgeIdVector,


### PR DESCRIPTION
# Fix Badge Issuer Address Handling

## Description
This PR fixes an issue with badge issuer addresses in the StepModal component when creating communities with badges. It properly uses the badge's specific issuer address instead of defaulting to the logged-in user's address, and ensures addresses are standardized to uppercase format for Stellar network compatibility.

## Changes
- Modified the badge creation logic to use the proper issuer address from form data instead of the logged-in user's address
- Added `.toUpperCase()` to ensure Stellar addresses are consistently formatted in uppercase, preventing potential case-sensitivity issues

## Context
Previously, when creating a community with badges, all badges were incorrectly assigned the current user's address as the issuer, regardless of what was entered in the issuer field. This fix ensures each badge correctly uses its designated issuer address. 