### PR TITLE
add: sort in the badge map

### DIFF
--- a/src/components/molecules/StepModal.tsx
+++ b/src/components/molecules/StepModal.tsx
@@ -345,6 +345,8 @@ export const StepModal: React.FC<ModalProps> = ({
         return;
       }
 
+      const sortedBadges = filteredBadges.sort((a, b) => a.name.localeCompare(b.name));
+
       const { pubkey } = await albedo.publicKey({
         require_existing: true,
       }); //Todo-user logged
@@ -366,7 +368,7 @@ export const StepModal: React.FC<ModalProps> = ({
       const saltScVal = xdr.ScVal.scvBytes(saltBuffer);
       const adminAddressScVal = new Address(pubkey).toScVal();
 
-      const badgeMapEntries: xdr.ScMapEntry[] = filteredBadges.map(
+      const badgeMapEntries: xdr.ScMapEntry[] = sortedBadges.map(
         badgeType => {
           const badgeIdVector = xdr.ScVal.scvVec([
             xdr.ScVal.scvString(badgeType.name),


### PR DESCRIPTION
# Fix: Implement Deterministic Ordering for Badge Maps in Soroban Transactions

## Problem

When preparing Soroban transactions containing ScMap data structures with badge information, the transaction would fail with:
```
Error during transaction preparation: Error: HostError: Error(Object, InvalidInput)
```

This occurred because Soroban requires lexicographical (alphabetical) ordering of keys in ScMaps for deterministic serialization and transaction signing.

## Solution

Implemented deterministic sorting of badges by name before creating the ScMap entries:
```javascript
const sortedBadges = filteredBadges.sort((a, b) => a.name.localeCompare(b.name));
```

## Root Cause

As documented in Stellar's rs-stellar-xdr repository (issues #98 and #107), ScMaps must maintain strict ordering for consistent serialization and cryptographic signing. This requirement isn't well-documented in Soroban's developer materials, making it a challenging bug to diagnose.

This fix ensures our transactions comply with Soroban's serialization requirements, enabling successful badge issuance transactions regardless of the original order of badge data.
